### PR TITLE
Enhance search modal interaction

### DIFF
--- a/components/ui/command-palette.tsx
+++ b/components/ui/command-palette.tsx
@@ -4,7 +4,7 @@ import { Command } from "cmdk";
 import { Search, Home, User, Settings, Sun, Moon, X } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import { cn } from "@/lib/utils";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 interface CommandPaletteProps {
   isOpen: boolean;
@@ -14,6 +14,8 @@ interface CommandPaletteProps {
 }
 
 export function CommandPalette({ isOpen, onClose, isDarkMode, onToggleTheme }: CommandPaletteProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
   // Handle keyboard events when command palette is open
   useEffect(() => {
     if (!isOpen) return;
@@ -29,6 +31,18 @@ export function CommandPalette({ isOpen, onClose, isDarkMode, onToggleTheme }: C
     document.addEventListener('keydown', handleKeyDown, true);
     return () => document.removeEventListener('keydown', handleKeyDown, true);
   }, [isOpen, onClose]);
+
+  // Auto-focus the input when the command palette opens
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      // Use a small delay to ensure the animation has started
+      const timer = setTimeout(() => {
+        inputRef.current?.focus();
+      }, 100);
+      
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
   return (
     <AnimatePresence>
       {isOpen && (
@@ -59,6 +73,7 @@ export function CommandPalette({ isOpen, onClose, isDarkMode, onToggleTheme }: C
                   ? "bg-black/20 border-white/10" 
                   : "bg-white/80 border-gray-200/50"
               )}
+              onClick={(e) => e.stopPropagation()}
             >
               {/* Search Input */}
               <div className="flex items-center border-b border-gray-200/20 px-4">
@@ -67,6 +82,7 @@ export function CommandPalette({ isOpen, onClose, isDarkMode, onToggleTheme }: C
                   isDarkMode ? "text-gray-300" : "text-gray-500"
                 )} />
                 <Command.Input
+                  ref={inputRef}
                   placeholder="Search commands..."
                   className={cn(
                     "flex h-12 w-full bg-transparent py-3 text-sm outline-none placeholder:text-gray-500",


### PR DESCRIPTION
Add auto-focus to the command palette input and prevent internal clicks from closing it.

The auto-focus ensures users can start typing immediately upon opening the palette. The click-outside functionality was refined by adding `stopPropagation` to the command palette container, preventing accidental closure when clicking within the modal itself.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-75d93b63-b36a-4c6e-8854-df146ff3e250) · [Cursor](https://cursor.com/background-agent?bcId=bc-75d93b63-b36a-4c6e-8854-df146ff3e250)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)